### PR TITLE
f-string instead of .format()

### DIFF
--- a/other_scripts/check_accentor.py
+++ b/other_scripts/check_accentor.py
@@ -6,7 +6,7 @@ import sys
 import nltk
 from rnnmorph.predictor import RNNMorphPredictor
 
-from russian_g2p import Accentor
+from russian_g2p.Accentor import Accentor
 
 
 VOWEL_LETTERS = {'а', 'о', 'у', 'э', 'ы', 'и', 'я', 'ё', 'ю', 'е'}

--- a/russian_g2p/Accentor.py
+++ b/russian_g2p/Accentor.py
@@ -38,11 +38,11 @@ class Accentor:
         assert mode in ('one', 'many'), 'Set either "one" or "many" variant mode!'
         assert debug in ('yes', 'no'), 'Set either "yes" or "no" variant mode!'
         homograph_dictionary_name = os.path.join(os.path.dirname(__file__), 'data', 'homographs.json')
-        assert os.path.isfile(homograph_dictionary_name), 'File `{0}` does not exist!'.format(homograph_dictionary_name)
+        assert os.path.isfile(homograph_dictionary_name), f'File `{homograph_dictionary_name}` does not exist!'
         simple_words_dawg_name = os.path.join(os.path.dirname(__file__), 'data', 'simple_words.dawg')
-        assert os.path.isfile(simple_words_dawg_name), 'File `{0}` does not exist!'.format(simple_words_dawg_name)
+        assert os.path.isfile(simple_words_dawg_name), f'File `{simple_words_dawg_name}` does not exist!'
         function_words_name = os.path.join(os.path.dirname(__file__), 'data', 'Function_words.json')
-        assert os.path.isfile(function_words_name), 'File `{0}` does not exist!'.format(function_words_name)
+        assert os.path.isfile(function_words_name), f'File `{function_words_name}` does not exist!'
         data = None
         try:
             d = dawg.IntDAWG()
@@ -50,28 +50,28 @@ class Accentor:
             ###
             with codecs.open(homograph_dictionary_name, mode='r', encoding='utf-8', errors='ignore') as fp:
                 data = json.load(fp)
-            error_message_homographs = 'File `{0}` contains incorrect data!'.format(homograph_dictionary_name)
+            error_message_homographs = f'File `{homograph_dictionary_name}` contains incorrect data!'
             assert isinstance(data, dict), error_message_homographs
             self.__homonyms = dict()
             for cur_wordform in data:
                 assert self.check_source_wordform(cur_wordform), \
-                    error_message_homographs + ' Word `{0}` is inadmissible!'.format(cur_wordform)
+                    error_message_homographs + f' Word `{cur_wordform}` is inadmissible!'
                 assert (cur_wordform not in self.__homonyms) and (cur_wordform.lower() not in self.__simple_words_dawg), \
-                    error_message_homographs + ' Word `{0}` is repeated!'.format(cur_wordform)
+                    error_message_homographs + f' Word `{cur_wordform}` is repeated!'
                 assert isinstance(data[cur_wordform], dict), \
-                    error_message_homographs + ' Word `{0}` has incorrect description of accents!'.format(cur_wordform)
+                    error_message_homographs + f' Word `{cur_wordform}` has incorrect description of accents!'
                 for cur_key in data[cur_wordform]:
                     assert self.check_morphotag(cur_key), \
-                        error_message_homographs + ' Word `{0}` has incorrect description of accents!'.format(cur_wordform)
+                        error_message_homographs + f' Word `{cur_wordform}` has incorrect description of accents!'
                     assert self.check_accented_wordform(data[cur_wordform][cur_key]), \
-                        error_message_homographs + ' Word `{0}` has incorrect description of accents!'.format(cur_wordform)
+                        error_message_homographs + f' Word `{cur_wordform}` has incorrect description of accents!'
                 values = [data[cur_wordform][it] for it in data[cur_wordform]]
                 self.__homonyms[cur_wordform] = copy.deepcopy(data[cur_wordform])
             ###
             self.__function_words = None
             with codecs.open(function_words_name, mode='r', encoding='utf-8', errors='ignore') as fp:
                 function_words = json.load(fp)
-            error_message_function_words = 'File `{0}` contains incorrect data!'.format(function_words_name)
+            error_message_function_words = f'File `{function_words_name}` contains incorrect data!'
             assert isinstance(function_words, list), error_message_function_words
             assert isinstance(function_words[0], str), error_message_function_words
             self.__function_words = function_words
@@ -251,7 +251,7 @@ class Accentor:
     def load_wiki_page(self, cur_form):
         if not self.use_wiki:
             if self.exception_for_unknown:
-                raise ValueError('Word `{0}` is unknown!'.format(cur_form))
+                raise ValueError(f'Word `{cur_form}` is unknown!')
             return
         query = urllib.parse.urlencode({ 'title' : cur_form })
         try:
@@ -259,7 +259,7 @@ class Accentor:
         except:
             http_exception_type = urllib.request.HTTPError
         try:
-            with urllib.request.urlopen('https://en.wiktionary.org/w/index.php?{}&#printable=yes'.format(query)) as f:
+            with urllib.request.urlopen(f'https://en.wiktionary.org/w/index.php?{query}&#printable=yes') as f:
                 root_text = f.read().decode('utf-8')
                 return root_text
         except http_exception_type:
@@ -267,7 +267,7 @@ class Accentor:
 
     def do_accents(self, source_phrase_and_morphotags: list) -> list:
         self.logger.debug('Checking the source phrase...')
-        error_message = '`{0}`: the phrase should be of a "list of lists" format!\nExample: [["word1","morphotag1"], ["word2","morphotag2"]] or [["word1"], ["word2"]]'.format(source_phrase_and_morphotags)
+        error_message = f'`{source_phrase_and_morphotags}`: the phrase should be of a "list of lists" format!\nExample: [["word1","morphotag1"], ["word2","morphotag2"]] or [["word1"], ["word2"]]'
         assert isinstance(source_phrase_and_morphotags, list), error_message
         try:
             assert isinstance(source_phrase_and_morphotags[0], list), error_message
@@ -280,14 +280,14 @@ class Accentor:
             morphotags_of_phrase = None
         for pair in source_phrase_and_morphotags:
             assert len(pair) == len(source_phrase_and_morphotags[0]), \
-                '`{0}`: morphotags do not correspond to words!'.format(' '.join(source_phrase))
+                f"`{' '.join(source_phrase)}`: morphotags do not correspond to words!"
         prepared_phrase = []
         for cur_word in source_phrase:
-            assert len(cur_word.strip()) > 0, '`{0}`: this phrase is wrong!'.format(source_phrase)
+            assert len(cur_word.strip()) > 0, f'`{source_phrase}`: this phrase is wrong!'
             prepared_phrase.append(cur_word.strip().lower())
         if morphotags_of_phrase is not None:
             assert len(prepared_phrase) == len(morphotags_of_phrase), \
-                '`{0}`: morphotags do not correspond to words!'.format(' '.join(source_phrase))
+                f"`{' '.join(source_phrase)}`: morphotags do not correspond to words!"
         assert len(prepared_phrase) > 0, 'Source phrase is empty!'
         try:
             res = self.__do_accents(prepared_phrase, morphotags_of_phrase)
@@ -450,11 +450,11 @@ class Accentor:
                     if cur in self.__russian_vowels:
                         vowels_counter += 1
                 if (cur_word in self.__function_words) or (vowels_counter == 0) or (('-' + cur_word) in self.__function_words) or ((cur_word + '-') in self.__function_words):
-                    self.logger.debug('The word {} is in the list of function words'.format(cur_word))
+                    self.logger.debug(f'The word `{cur_word}` is in the list of function words')
                     accented_wordforms += [cur_word]
                     accented_wordforms_many.append([cur_word])
                 elif vowels_counter == 1:
-                    self.logger.debug('The word {} has one vowel: accented automatically'.format(cur_word))
+                    self.logger.debug(f'The word `{cur_word}` has one vowel: accented automatically')
                     cur_vowel = list(set(cur_word) & self.__russian_vowels)[0]
                     pos = cur_word.find(cur_vowel)
                     try:
@@ -464,12 +464,12 @@ class Accentor:
                         accented_wordforms += [cur_word[:pos] + '+']
                         accented_wordforms_many.append([cur_word[:pos] + '+'])
                 elif cur_word in self.__simple_words_dawg:
-                    self.logger.debug('The word {} is in the dictionary of simple words'.format(cur_word))
+                    self.logger.debug(f'The word `{cur_word}` is in the dictionary of simple words')
                     accented_wordform = cur_word[:self.__simple_words_dawg[cur_word]] + '+' + cur_word[self.__simple_words_dawg[cur_word]:]
                     accented_wordforms += [accented_wordform]
                     accented_wordforms_many.append([accented_wordform])
                 elif cur_word in self.__homonyms:
-                    self.logger.debug('The word {} is in the dictionary of homonyms'.format(cur_word))
+                    self.logger.debug(f'The word `{cur_word}` is in the dictionary of homonyms')
                     if (morphotags_list is None) or morphotags_list[0].isdigit():
                         accented_wordforms += [cur_word]
                         accented_wordforms_many.append(sorted([self.__homonyms[cur_word][it] for it in self.__homonyms[cur_word]]))
@@ -508,7 +508,7 @@ class Accentor:
                                 accented_wordforms_many.append(sorted([self.__homonyms[cur_word][it] for it in self.__homonyms[cur_word]]))
                                 warn = 'many'
                 else:
-                    self.logger.debug('The word {} was not found in any of the dictionaries\nTrying to parse wictionary page...'.format(cur_word))
+                    self.logger.debug(f'The word `{cur_word}` was not found in any of the dictionaries\nTrying to parse wictionary page...')
                     root_text = self.load_wiki_page(cur_word)
                     if root_text != None:
                         cur_accented_wordforms = sorted(self.get_simple_form_wiki(root_text, cur_word))
@@ -553,9 +553,9 @@ class Accentor:
             accented_wordforms = [accented_wordforms[accented_wordforms.index(cur_token)]]
             if warn != '':
                 if warn == 'many':
-                    err_msg = 'Word `{0}` has too many accent variants!'.format(cur_token)
+                    err_msg = f'Word `{cur_token}` has too many accent variants!'
                 else:  # warn == 'no':
-                    err_msg = 'Word `{0}` is unknown!'.format(cur_token)
+                    err_msg = f'Word `{cur_token}` is unknown!'
                 if self.exception_for_unknown:
                     raise ValueError(err_msg)
                 self.__bad_words.append(cur_token)

--- a/russian_g2p/Accentor.py
+++ b/russian_g2p/Accentor.py
@@ -94,7 +94,6 @@ class Accentor:
         del self.__function_words
 
     def get_correct_omograph_wiki(self, root_text, cur_word, morphotag='X'):
-
         '''
         Разбор омографии.
         Использование морфологической информации о 
@@ -134,7 +133,7 @@ class Accentor:
                     result = ''.join(result)
                 else:
                     continue
-                if result.replace('ё', 'е́').find('́') != -1:
+                if result.replace('ё', 'е́').find('') != -1:
                     shallow_vars.add(result)
                 if header.text_content()[0] == morphotag[0]:
                     #print('The tags are equal')
@@ -193,17 +192,15 @@ class Accentor:
                 results.add(result)
         #print(shallow_vars)
         if len(list(shallow_vars)) == 1:
-            if list(shallow_vars)[0].replace('ё', 'е+').replace('́', '') == cur_word:
-                return [list(shallow_vars)[0].replace('ё', 'ё+').replace('́', '+').replace('́', '+')]
+            if list(shallow_vars)[0].replace('ё', 'е+').replace('', '') == cur_word:
+                return [list(shallow_vars)[0].replace('ё', 'ё+').replace('', '+').replace('', '+')]
         #print(results)
         if len(list(results)) != 1:
             return []
-        best_results = [variant.replace('́', '+') for variant in results]
-
+        best_results = [variant.replace('', '+') for variant in results]
         return list(best_results)
 
     def get_simple_form_wiki(self, root_text, form):
-
         '''
         Непосредственное нахождение релевантной формы
         и ударение без морфологической информации.
@@ -212,33 +209,33 @@ class Accentor:
         rel_forms = set()
         for header in root.findall('.//*[@class="Cyrl headword"][@lang="ru"]'):
             header_text = header.text_content().replace('ё', 'е́')
-            header_text_best = header.text_content().replace('ё', 'ё+').replace('́', '+')
-            if header_text.replace('́', '') == form:
-                if header_text.find('́') != -1:
+            header_text_best = header.text_content().replace('ё', 'ё+').replace('', '+')
+            if header_text.replace('', '') == form:
+                if header_text.find('') != -1:
                     rel_forms.add(header_text_best)
         for mention in root.findall('.//i[@class="Cyrl mention"][@lang="ru"]'):
             mention_text = mention.text_content().replace('ё', 'е́')
-            mention_text_best = mention.text_content().replace('ё', 'ё+').replace('́', '+')
-            if mention_text.replace('́', '') == form:
-                if mention_text.replace('ё', 'е́').find('́') != -1:
+            mention_text_best = mention.text_content().replace('ё', 'ё+').replace('', '+')
+            if mention_text.replace('', '') == form:
+                if mention_text.replace('ё', 'е́').find('') != -1:
                     rel_forms.add(mention_text_best)
         for mention in root.findall('.//b[@class="Cyrl"][@lang="ru"]'):
             mention_text = mention.text_content().replace('ё', 'е́')
-            mention_text_best = mention.text_content().replace('ё', 'ё+').replace('́', '+')
-            if mention_text.replace('́', '') == form:
-                if mention_text.replace('ё', 'е́').find('́') != -1:
+            mention_text_best = mention.text_content().replace('ё', 'ё+').replace('', '+')
+            if mention_text.replace('', '') == form:
+                if mention_text.replace('ё', 'е́').find('') != -1:
                     rel_forms.add(mention_text_best)
             elif mention_text.find('(') != -1:
-                if mention_text.replace('́', '').find(form) != -1:
-                    if mention_text.find('́') != -1:
-                        rel_forms.add(mention_text_best[mention_text.replace('́', '').find(form):])
+                if mention_text.replace('', '').find(form) != -1:
+                    if mention_text.find('') != -1:
+                        rel_forms.add(mention_text_best[mention_text.replace('', '').find(form):])
                 elif re.sub(r'[\(\)́]', '', mention_text) == form:
                     rel_forms.add(re.sub(r'[\(\)]', '', mention_text_best))
         for target in root.xpath('.//span[@class="Cyrl"][@lang="ru"]'):
             one_form = target.text_content()
-            if one_form.replace('ё', 'е́').replace('́', '') == form:
-                if one_form.replace('ё', 'е́').find('́') != -1:
-                    rel_forms.add(one_form.replace('ё', 'ё́').replace('́', '+'))
+            if one_form.replace('ё', 'е́').replace('', '') == form:
+                if one_form.replace('ё', 'е́').find('') != -1:
+                    rel_forms.add(one_form.replace('ё', 'ё́').replace('', '+'))
         results = list(rel_forms)
         if len(results) == 2:
             if results[0].replace('ё', 'е') == results[1].replace('ё', 'е'):

--- a/russian_g2p/Grapheme2Phoneme.py
+++ b/russian_g2p/Grapheme2Phoneme.py
@@ -28,7 +28,7 @@ class Grapheme2Phoneme(RulesForGraphemes):
         self.__exclusions_dictionary = None
         exclusions_dictionary_name = os.path.join(os.path.dirname(__file__), 'data', 'Phonetic_Exclusions.txt')
         assert os.path.isfile(exclusions_dictionary_name), \
-            'File `{0}` does not exist!'.format(exclusions_dictionary_name)
+            f'File `{exclusions_dictionary_name}` does not exist!'
         self.__exclusions_dictionary = self.load_exclusions_dictionary(exclusions_dictionary_name)
         self.__re_for_phrase_split = re.compile(r'[\s\-]+', re.U)
 
@@ -50,8 +50,8 @@ class Grapheme2Phoneme(RulesForGraphemes):
             cur_line = dictionary_file.readline()
             cur_line_index = 1
             while len(cur_line):
-                error_message = "File `{0}`, line {1}: description of this word and its transformation is " \
-                                "incorrect!".format(file_name, cur_line_index)
+                error_message = f"File `{file_name}`, line {cur_line_index}: description of this word and its transformation is " \
+                                "incorrect!"
                 prepared_line = cur_line.strip()
                 if len(prepared_line):
                     words_of_line = prepared_line.lower().split()
@@ -69,22 +69,22 @@ class Grapheme2Phoneme(RulesForGraphemes):
     def check_word(self, checked_word: str):
         assert len(checked_word) > 0, 'Checked word is empty string!'
         assert all([c in (self.mode.all_russian_letters | {'+', '-'}) for c in checked_word.lower()]), \
-            '`{0}`: this word contains inadmissible characters!'.format(checked_word)
+            f'`{checked_word}`: this word contains inadmissible characters!'
         assert len(list(filter(lambda c: c in self.mode.all_russian_letters, checked_word.lower()))) > 0, \
-            '`{0}`: this word is incorrect!'.format(checked_word)
+            f'`{checked_word}`: this word is incorrect!'
 
     def check_phrase(self, checked_phrase: str):
         assert len(checked_phrase) > 0, 'Checked phrase is empty string!'
         assert all([c in (self.mode.all_russian_letters | {' ', '+', '-'} | {'s', 'i', 'l'})
                     for c in checked_phrase.lower()]), \
-            '`{0}`: this phrase contains inadmissible characters!'.format(checked_phrase)
+            f'`{checked_phrase}`: this phrase contains inadmissible characters!'
         # for cur_word in self.__re_for_phrase_split.split(checked_phrase.lower()):
         # assert (len(list(filter(lambda c: c in self.all_russian_letters, cur_word))) > 0) \
-        #      or (cur_word.lower() == 'sil'), '`{0}`: this phrase is incorrect!'.format(checked_phrase)
+        #      or (cur_word.lower() == 'sil'), f'`{checked_phrase}`: this phrase is incorrect!'
 
     def word_to_phonemes(self, source_word: str, next_phoneme: str = 'sil') -> list:
         self.check_word(source_word)
-        error_message = '`{0}`: this word is incorrect!'.format(source_word)
+        error_message = f'`{source_word}`: this word is incorrect!'
         prepared_word = source_word.lower()
         if prepared_word in self.__exclusions_dictionary:
             prepared_word = self.__exclusions_dictionary[prepared_word]
@@ -92,8 +92,8 @@ class Grapheme2Phoneme(RulesForGraphemes):
             counter = len(prepared_word) - len(re.sub(r'[аоуэыияёею]', '', prepared_word))
             if counter > 1:
                 if self.exception_for_nonaccented:
-                    raise ValueError('`{0}`: the accent for this word is unknown!'.format(source_word))
-                warnings.warn('`{0}`: the accent for this word is unknown!'.format(source_word))
+                    raise ValueError(f'`{source_word}`: the accent for this word is unknown!')
+                warnings.warn(f'`{source_word}`: the accent for this word is unknown!')
         if prepared_word in self.__exclusions_dictionary:
             prepared_word = self.__exclusions_dictionary[prepared_word]
         prepared_word = prepared_word.replace('\'', '')
@@ -127,11 +127,11 @@ class Grapheme2Phoneme(RulesForGraphemes):
             ind -= 1
             transcription = new_phonemes + transcription
             next_phoneme = new_phonemes[0]
-        assert len(transcription) > 0, '`{0}`: this word cannot be transcribed!'.format(source_word)
+        assert len(transcription) > 0, f'`{source_word}`: this word cannot be transcribed!'
         return self.__remove_long_phonemes(self.__remove_repeats_from_transcription(transcription))
 
     def phrase_to_phonemes(self, source_phrase: str) -> list:
-        error_message = '`{0}`: this phrase is incorrect!'.format(source_phrase)
+        error_message = f'`{source_phrase}`: this phrase is incorrect!'
         source_phrase = source_phrase.lower().replace('-', ' ')
         source_phrase = re.sub('[^a-zйцукенгшщзхъфывапролджэячсмитьбюё+ ]', '', source_phrase)
         self.check_phrase(source_phrase)
@@ -202,7 +202,7 @@ class Grapheme2Phoneme(RulesForGraphemes):
 
     def __word_to_letters_list(self, cur_word: str) -> list:
         vocal_letters = set(filter(lambda letter: not letter.endswith('+'), self.mode.vocals))
-        error_message = "`{0}`: this word is incorrect!".format(cur_word)
+        error_message = f"`{cur_word}`: this word is incorrect!"
         letters_list = list()
         new_letter = ''
         for ind in range(len(cur_word)):

--- a/russian_g2p/Preprocessor.py
+++ b/russian_g2p/Preprocessor.py
@@ -27,7 +27,7 @@ class Preprocessor():
 
     def gettags(self, texts):
         if not isinstance(texts, list):
-            raise ValueError('Expected `{0}`, but got `{1}`.'.format(type([1, 2]), type(texts)))
+            raise ValueError(f'Expected `{type([1, 2])}`, but got `{type(texts)}`.')
         if len(texts) == 0:
             return []
         all_phonetic_phrases = []

--- a/russian_g2p/Transcription.py
+++ b/russian_g2p/Transcription.py
@@ -47,7 +47,7 @@ class Transcription:
             if (part_size > 0) and self.verbose:
                 if (data_counter % part_size) == 0:
                     part_counter += 1
-                    print('{0}% of texts have been processed...'.format(part_counter))
+                    print(f'{part_counter}% of texts have been processed...')
         if (part_counter < n_data_parts) and self.verbose:
             print('100% of texts have been processed...')
         return total_result


### PR DESCRIPTION
Suggestion to use f-strings instead of .format() for the code compactness and clarity. See [PEP 498](https://www.python.org/dev/peps/pep-0498/).